### PR TITLE
CLA-1423: add code to set the call duration for failed calls to 0

### DIFF
--- a/clarity-file-uploads/routes/routes.js
+++ b/clarity-file-uploads/routes/routes.js
@@ -160,6 +160,10 @@ const downloadPendingRecordings = async (currentUserId, eventId, shopperId) => {
           const client = init();
           // fetch call detail
           const callDetails = await client.recordings(recording.twilioPendingRecordingId).fetch();
+
+          if(callDetails.duration === -1){
+            callDetails.duration = 0;
+          }
       
           const fileInfo = {
             storagePath,


### PR DESCRIPTION
Failed calls have a duration of -1, a value that introduces bugs when used with the Date object